### PR TITLE
Time Printing, Config File Bug Fix, Use Cuda Option

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -60,7 +60,7 @@ from model import TIS_Net
 from sklearn.model_selection import KFold
 from config import N_FOLDS, N_CLUSTERS, MODEL_NAME, X_s, X_t
 from helper import cast_source_to_DGN_input, cast_target_to_DGN_input, cluster_with_SIMLR, print_final_results, save_fig, print_fold_specific_results, calc_norm_distances
-
+import time
 kf = KFold(n_splits=N_FOLDS)
 
 """
@@ -92,6 +92,9 @@ for train_index, test_index in kf.split(X_s):
     print(10 * "#" + " FOLD " + str(fold) + " " + 10 * "#")
 
     X_train_source, X_test_source, X_train_target, X_test_target = X_s[train_index], X_s[test_index], X_t[train_index], X_t[test_index]
+
+    # Calculating the time passed for each epoch
+    start = time.time()
 
     # SIMLR clustering
     X_casted_train_source_clusters  = cluster_with_SIMLR(X_train_source, cast_source_to_DGN_input, N_CLUSTERS)
@@ -132,8 +135,11 @@ for train_index, test_index in kf.split(X_s):
     # Calculate norm distances between predicted CBT and each test subject
     mean_norm_distance_fold_specific = np.mean(calc_norm_distances(predicted_CBT, X_test_target))
 
-    # Print results for each fold on stdout
-    print_fold_specific_results(fold, evaluation_results_fold_specific, mean_norm_distance_fold_specific)
+    # Calculate passed time
+    elaplasedTime = time.time() - start
+
+    # Print results for each fold on stdout with time passed
+    print_fold_specific_results(fold, evaluation_results_fold_specific, mean_norm_distance_fold_specific,elaplasedTime)
 
     # Save figures of predicted and ground-truth CBTs in "output/{MODEL_NAME}" folder
     save_fig(predicted_CBT, f"Predicted CBT for fold {fold}", f"pred_CBT_fold_{fold}.png")

--- a/helper.py
+++ b/helper.py
@@ -26,7 +26,7 @@ def calc_norm_distances(predicted_CBT, X_test_target):
     return norm_dists
 
 
-def print_fold_specific_results(fold, evaluation_results_fold_specific, mean_norm_distance_fold_specific):
+def print_fold_specific_results(fold, evaluation_results_fold_specific, mean_norm_distance_fold_specific,elaplasedTime):
     """
         Prints the test results for the current fold
 
@@ -46,6 +46,10 @@ def print_fold_specific_results(fold, evaluation_results_fold_specific, mean_nor
     print("MAE(Eigenvector Centrality) ", str(evaluation_results_fold_specific["MAE(EC)"].item()))
     print("MAE(Betweenness Centrality): ", str(evaluation_results_fold_specific["MAE(BC)"].item()))
     print("Mean Norm Distance Between Each Test Subject and Predicted CBT: " + str(mean_norm_distance_fold_specific))
+
+    # Printing the time elaplased for each epoch
+    print("Time elapsed :", elaplasedTime)
+
     print()
 
 
@@ -405,3 +409,23 @@ def cast_to_DGN_graph(array_of_tensors, subject_type=None, flat_mask=None):
                     con_mat=con_mat,  y=y, label=subject_type)
         dataset.append(data)
     return dataset
+
+
+def squareMatrixToHorizantal(square_matrix_data_set):
+    """
+        This function is designed for users who want to use a dataset that is square matrix
+        It takes the square matrix and vectorizes its upper off-diagonal triangular part.
+        Then return the result
+        Parameters:
+            np.array: A dataset with shape [N_SUBJECTS, N_DIMENTION, N_DIMENTION]
+
+        Returns:
+            np.array: Array with shape [N_SUBJECTS, N_DIMENTION*(N_DIMENTION-1)*0.5]
+    
+    """
+    size,square_matrix_size = square_matrix_data_set.shape[0], square_matrix_data_set.shape[1]
+    row_lenght =int(square_matrix_size * (square_matrix_size-1) * 0.5)
+    result = np.zeros([size,row_lenght])
+    for i in range(0,len(square_matrix_data_set)):
+        result[i] = square_matrix_data_set[i][np.triu_indices(square_matrix_size,k = 1)]
+    return result

--- a/model.py
+++ b/model.py
@@ -7,7 +7,7 @@ from torch_geometric.nn import NNConv
 from torch_geometric.nn import GCNConv
 from torch_geometric.nn import BatchNorm
 import numpy as np
-from config import N_CLUSTERS, N_SOURCE_NODES, N_TARGET_NODES, DGN_MODEL_PARAMS_SOURCE, DGN_MODEL_PARAMS_TARGET, N_EPOCHS, N_CLUSTERS
+from config import N_CLUSTERS, N_SOURCE_NODES, N_TARGET_NODES, DGN_MODEL_PARAMS_SOURCE, DGN_MODEL_PARAMS_TARGET, N_EPOCHS, N_CLUSTERS, USE_CUDA
 from helper import cast_to_DGN_graph, source_to_graph
 from random import sample
 from centrality import topological_measures
@@ -136,8 +136,8 @@ class DGN(torch.nn.Module):
 
 class TIS_Net():
     def __init__(self):
-        # Use cuda if avaliable
-        if torch.cuda.is_available():
+        # Use cuda if avaliable and the user wants to use cuda
+        if torch.cuda.is_available() and USE_CUDA:
             self.device = torch.device("cuda:0")
             print("Running on cuda")
         else:


### PR DESCRIPTION
**Firstly**, I implemented the fold-specific time functionality. After each of the folds, the elapsed time is printed to the terminal.

**Secondly**, there is a logic error that I detected in the Config File. In the config file, users can use external data. The current implementation assumes that external data's graph matrixes are square matrices. However, I cannot see that these square matrixes transform themselves to vectorized upper off-diagonal triangular parts. I believe this step is missed thus, I implemented a function in the _helper.py_ file called **"squareMatrixToHorizantal"**. This function takes data as n times square matrix and transforms it to n times vectorized upper off-diagonal triangular parts.

**Thirdly**, if a user wants to use already vectorized upper off-diagonal triangular-based data, I implemented the **"E2"** mode. In this mode, data is directly passed to TIS-Net since it is already in the desired shape.

**Fourthly,** I created a variable called **"USE_CUDA"** in the config file because some people still want to use CPU despite having CUDA available GPU.  Users can now change this variable to True or False depending on their need in the config file.